### PR TITLE
update dsl sync for the new real-time engine

### DIFF
--- a/lib/cluster/node.js
+++ b/lib/cluster/node.js
@@ -1,4 +1,6 @@
-var 
+'use strict';
+
+var
   RequestObject = require('kuzzle-common-objects').Models.requestObject;
 
 function Node (clusterHandler, context, options) {
@@ -11,21 +13,18 @@ function Node (clusterHandler, context, options) {
   this.isReady = false;
 }
 
-Node.prototype.addDiffListener = function () {
-  this.broker.listen('cluster:update', merge.bind(this));
+Node.prototype.addDiffListener = function addDiffListener () {
+  this.broker.listen('cluster:update', this.merge);
 };
 
-Node.prototype.destroy = function () {
+Node.prototype.destroy = function destroy () {
   this.broker.reconnect = false;
   this.broker.close();
-  
+
   this.isReady = false;
 };
 
-module.exports = Node;
-
-
-function merge (diffs) {
+Node.prototype.merge = function merge (diffs) {
   this.kuzzle.pluginsManager.trigger('log:debug', `[cluster::merge] ${JSON.stringify(diffs)}`);
 
   if (!Array.isArray(diffs)) {
@@ -33,45 +32,45 @@ function merge (diffs) {
   }
 
   diffs.forEach(diff => {
-    switch (Object.keys(diff)[0]) {
-      // indexCache::add
-      case 'icAdd':
-        this.kuzzle.indexCache.add(diff.icAdd.i, diff.icAdd.c, false);
-        break;
-      // indexCache::remove
-      case 'icDel':
-        this.kuzzle.indexCache.remove(diff.icDel.i, diff.icDel.c, false);
-        break;
-      // indexCache::reset
-      case 'icReset':
-        this.kuzzle.indexCache.reset(diff.icReset.i, false);
-        break;
-      case 'hcR':
-        mergeAddRoom.call(this, diff.hcR);
-        break;
-      case 'hcDel':
-        mergeDelRoom.call(this, diff.hcDel);
-        break;
-      case 'hcDelMul':
-        mergeDelRooms.call(this, diff.hcDelMul);
-        break;
-      // filterTree
-      case 'ft':
-        mergeFilterTree.call(this, diff.ft);
-        break;
-      // filterTree global subscription
-      case 'ftG':
-        this.kuzzle.dsl.filters.addCollectionSubscription(diff.ftG.fi, diff.ftG.i, diff.ftG.c);
-        break;
-      // autoRefresh
-      case 'ar':
-        updateAutoRefresh.call(this, diff.ar.i, diff.ar.v);
-        break;
-    }
+    Object.keys(diff)
+      .filter(k => typeof diff[k] === 'object' && !Array.isArray(diff[k]))
+      .forEach(k => {
+        switch (k) {
+          // indexCache::add
+          case 'icAdd':
+            this.kuzzle.indexCache.add(diff.icAdd.i, diff.icAdd.c, false);
+            break;
+          // indexCache::remove
+          case 'icDel':
+            this.kuzzle.indexCache.remove(diff.icDel.i, diff.icDel.c, false);
+            break;
+          // indexCache::reset
+          case 'icReset':
+            this.kuzzle.indexCache.reset(diff.icReset.i, false);
+            break;
+          case 'hcR':
+            mergeAddRoom(this.kuzzle.hotelClerk, diff.hcR);
+            break;
+          case 'hcDel':
+            mergeDelRoom(this.kuzzle.hotelClerk, diff.hcDel);
+            break;
+          case 'hcDelMul':
+            mergeDelRooms(this.kuzzle.hotelClerk, diff.hcDelMul);
+            break;
+          // dsl
+          case 'ftAdd':
+            this.kuzzle.dsl.storage.store(diff.ftAdd.i, diff.ftAdd.c, diff.ftAdd.f);
+            break;
+          // autoRefresh
+          case 'ar':
+            updateAutoRefresh(this.kuzzle.services.list.storageEngine, diff.ar.i, diff.ar.v);
+            break;
+        }
+      });
   });
-}
+};
 
-function mergeAddRoom (diff) {
+function mergeAddRoom (hotelClerk, diff) {
   var
     index = diff.i,
     collection = diff.c,
@@ -80,8 +79,8 @@ function mergeAddRoom (diff) {
     connection = diff.cx,
     metadata = diff.m;
 
-  if (!this.kuzzle.hotelClerk.rooms[roomId]) {
-    this.kuzzle.hotelClerk.rooms[roomId] = {
+  if (!hotelClerk.rooms[roomId]) {
+    hotelClerk.rooms[roomId] = {
       id: roomId,
       customers: [],
       index: index,
@@ -90,51 +89,29 @@ function mergeAddRoom (diff) {
     };
   }
 
-  if (!this.kuzzle.hotelClerk.rooms[roomId].channels[channel[0]]) {
-    this.kuzzle.hotelClerk.rooms[roomId].channels[channel[0]] = channel[1];
+  if (!hotelClerk.rooms[roomId].channels[channel[0]]) {
+    hotelClerk.rooms[roomId].channels[channel[0]] = channel[1];
   }
 
-  if (!this.kuzzle.hotelClerk.customers[connection.id] || !this.kuzzle.hotelClerk.customers[connection.id][roomId]) {
-    this.kuzzle.hotelClerk.addRoomForCustomer(connection, roomId, metadata);
+  if (!hotelClerk.customers[connection.id] || !hotelClerk.customers[connection.id][roomId]) {
+    hotelClerk.addRoomForCustomer(connection, roomId, metadata);
   }
 }
 
-function mergeDelRoom (diff) {
-  this.kuzzle.hotelClerk.removeRoomForCustomer(diff.c, diff.r, false);
+function mergeDelRoom (hotelClerk, diff) {
+  hotelClerk.removeRoomForCustomer(diff.c, diff.r, false);
 }
 
-function mergeDelRooms (diff) {
+function mergeDelRooms (hotelClerk, diff) {
   var requestObject = new RequestObject(
     { index: diff.i, collection: diff.c },
     { body: { rooms: diff.r } }
   );
-  
-  this.kuzzle.hotelClerk.removeRooms(requestObject);
+
+  hotelClerk.removeRooms(requestObject);
 }
 
-function mergeFilterTree (diff) {
-  var result = this.kuzzle.dsl.filters.add(
-    diff.i,
-    diff.c,
-    diff.f,
-    diff.o,
-    diff.v,
-    diff.fn,
-    diff.fi,
-    diff.n,
-    diff.g
-  );
-  this.kuzzle.dsl.filters.filters[diff.fi] = {
-    index: diff.i,
-    collection: diff.c,
-    encodedFilters: {
-      [result.path]: result.filter
-    }
-  };
-  
-}
-
-function updateAutoRefresh (index, value) {
+function updateAutoRefresh (storageEngine, index, value) {
   var requestObject = new RequestObject({
     index,
     controller: 'admin',
@@ -143,6 +120,7 @@ function updateAutoRefresh (index, value) {
     body: {autoRefresh: value}
   });
 
-  this.kuzzle.services.list.storageEngine.setAutoRefresh(requestObject);
+  storageEngine.setAutoRefresh(requestObject);
 }
 
+module.exports = Node;

--- a/test/lib/cluster/masterNode.test.js
+++ b/test/lib/cluster/masterNode.test.js
@@ -17,12 +17,12 @@ describe('lib/cluster/masterNode', () => {
         kuzzle: {
           services: { list: { broker: {} } },
           hotelClerk: { rooms: 'rooms', customers: 'customers' },
-          dsl: { filters: { filtersTree: 'filterTree', filters: 'filters' } },
+          dsl: { filters: { filters: 'filters' } },
           indexCache: { indexes: 'indexes' }
         }
       }},
     options = {some: 'options'};
-  
+
   afterEach(() => {
     sandbox.restore();
   });
@@ -30,7 +30,7 @@ describe('lib/cluster/masterNode', () => {
   describe('#constructor', () => {
 
     it('should setup a valid master node', () => {
-      var 
+      var
         node = new MasterNode(clusterHandler, context, options);
 
       should(node.clusterHandler).be.exactly(clusterHandler);
@@ -42,33 +42,33 @@ describe('lib/cluster/masterNode', () => {
       should(node.slaves).be.empty();
       should(node.isReady).be.false();
     });
-    
+
     it('should inherit from Node', () => {
       var node = new MasterNode(clusterHandler, context, options);
-      
+
       should(node).be.an.instanceOf(Node);
     });
-    
+
   });
 
   describe('#init', () => {
-    var 
+    var
       node,
       spy = sinon.spy(),
       revert;
-    
+
     before(() => {
       revert = MasterNode.__set__('attachEvents', spy);
       node = new MasterNode(clusterHandler, context, options);
     });
-    
+
     after(() => {
       revert();
     });
 
     it('should set the broker and attach the listeners', () => {
       node.init();
-      
+
       should(node.broker).be.exactly(context.accessors.kuzzle.services.list.broker);
       should(spy).be.calledOnce();
     });
@@ -92,29 +92,29 @@ describe('lib/cluster/masterNode', () => {
         slaves: {}
       },
       revert;
-    
+
     before(() => {
       revert = MasterNode.__set__({
         _context: 'context',
         Slave
       });
     });
-    
+
     after(() => {
       revert();
     });
 
     it('should do its job', () => {
-      
+
       attachEvents.call(node);
-      
+
       should(node.broker.listen).be.calledOnce();
       should(node.broker.listen).be.calledWith('cluster:join', cb);
       should(node.addDiffListener).be.calledOnce();
-      
+
       // cb test
       cb.call(node, {uuid:'foobar', options: {binding: 'binding'}});
-      
+
       should(node.broker.send).be.calledOnce();
       should(node.broker.send).be.calledWith('cluster:foobar', {
         action: 'snapshot',
@@ -130,9 +130,9 @@ describe('lib/cluster/masterNode', () => {
           ic: context.accessors.kuzzle.indexCache.indexes
         }
       });
-      
+
       should(node.broker.onErrorHandlers).have.length(1);
-      
+
       node.isReady = true;
       node.broker.onErrorHandlers[0]();
       should(node.isReady).be.false();

--- a/test/lib/cluster/node.test.js
+++ b/test/lib/cluster/node.test.js
@@ -26,12 +26,8 @@ describe('lib/cluster/node', () => {
             reset: sandbox.spy()
           },
           dsl: {
-            filters: {
-              add: sandbox.spy(() => {
-                return {path: 'path', filter: 'filter'};
-              }),
-              addCollectionSubscription: sandbox.spy(),
-              filters: {}
+            storage: {
+              store: sandbox.spy()
             }
           },
           hotelClerk: {
@@ -87,17 +83,17 @@ describe('lib/cluster/node', () => {
   });
 
   describe('#destroy', () => {
-    
+
     it('should do its job', () => {
       node.destroy();
-      
+
       should(node.broker.reconnect).be.false();
       should(node.broker.close).be.calledOnce();
       should(node.isReady).be.false();
     });
-    
+
   });
-  
+
   describe('#merge', () => {
     var
       merge,
@@ -108,10 +104,8 @@ describe('lib/cluster/node', () => {
         mergeAddRoom: sinon.spy(),
         mergeDelRoom: sinon.spy(),
         mergeDelRooms: sinon.spy(),
-        mergeFilterTree: sinon.spy(),
         updateAutoRefresh: sinon.spy()
       });
-      merge = Node.__get__('merge');
     });
 
     after(() => {
@@ -119,75 +113,67 @@ describe('lib/cluster/node', () => {
     });
 
     it('should call kuzzle.indexCache.add with proper values when an `icAdd` key is given', () => {
-      merge.call(node, {icAdd: {i: 'index', c: 'collection'}});
-      
+      node.merge({icAdd: {i: 'index', c: 'collection'}});
+
       should(node.kuzzle.indexCache.add).be.calledOnce();
       should(node.kuzzle.indexCache.add).be.calledWithExactly('index', 'collection', false);
     });
-    
+
     it('should call kuzzle.indexCache.remove with proper values when an `icDel` key is given', () => {
-      merge.call(node, {icDel: {i: 'index', c: 'collection'}});
-      
+      node.merge({icDel: {i: 'index', c: 'collection'}});
+
       should(node.kuzzle.indexCache.remove).be.calledOnce();
       should(node.kuzzle.indexCache.remove).be.calledWithExactly('index', 'collection', false);
     });
-    
+
     it('should call kuzzle.indexCache.reset with proper values when an `icReset` key is given', () => {
-      merge.call(node, {icReset: {i: 'index'}});
-      
+      node.merge({icReset: {i: 'index'}});
+
       should(node.kuzzle.indexCache.reset).be.calledOnce();
       should(node.kuzzle.indexCache.reset).be.calledWithExactly('index', false);
     });
 
     it('should call the mergeAddRoom function when an `hcR` key is given', () => {
-      merge.call(node, [{hcR: true}]);
+      node.merge([{hcR: {}}]);
 
       should(Node.__get__('mergeAddRoom')).be.calledOnce();
-      should(Node.__get__('mergeAddRoom')).be.calledWith(true);
+      should(Node.__get__('mergeAddRoom')).be.calledWith(node.kuzzle.hotelClerk, {});
     });
 
     it('should call the mergeDelRoom function when an `hcDel` key is given', () => {
-      merge.call(node, {hcDel: true});
+      node.merge({hcDel: {}});
 
       should(Node.__get__('mergeDelRoom')).be.calledOnce();
-      should(Node.__get__('mergeDelRoom')).be.calledWith(true);
+      should(Node.__get__('mergeDelRoom')).be.calledWith(node.kuzzle.hotelClerk, {});
     });
-    
+
     it('should call the mergeDelRooms function when an `hcDelMul` key is given', () => {
-      merge.call(node, {hcDelMul: true});
-      
+      node.merge({hcDelMul: {}});
+
       should(Node.__get__('mergeDelRooms')).be.calledOnce();
-      should(Node.__get__('mergeDelRooms')).be.calledWith(true);
+      should(Node.__get__('mergeDelRooms')).be.calledWith(node.kuzzle.hotelClerk, {});
     });
 
-    it('should call the mergeFilterTree function when an `ft`key is given', () => {
-      merge.call(node, {ft: true});
-
-      should(Node.__get__('mergeFilterTree')).be.calledOnce();
-      should(Node.__get__('mergeFilterTree')).be.calledWith(true);
-    });
-
-    it('should call kuzzle.dsl.filters.addCollectionSubscription with proper values when a `ftG` key is given', () => {
-      merge.call(node, {ftG: {i: 'index', c: 'collection', fi: 'filterId'}});
-      
-      should(node.kuzzle.dsl.filters.addCollectionSubscription).be.calledOnce();
-      should(node.kuzzle.dsl.filters.addCollectionSubscription).be.calledWithExactly('filterId', 'index', 'collection');
-    });
-    
     it('should call the updateAutoRefresh function when an `ar` key is given', () => {
-      merge.call(node, {ar: {i: 'index', v: 'value'}});
-      
+      node.merge({ar: {i: 'index', v: 'value'}});
+
       should(Node.__get__('updateAutoRefresh')).be.calledOnce();
-      should(Node.__get__('updateAutoRefresh')).be.calledWithExactly('index', 'value');
+      should(Node.__get__('updateAutoRefresh')).be.calledWithExactly(node.kuzzle.services.list.storageEngine, 'index', 'value');
     });
-    
+
+    it('should store the new filters subscription when an `ftAdd` key is given', () => {
+      node.merge({ftAdd: {i: 'index', c: 'collection', f: {some: 'filters'}}});
+
+      should(context.accessors.kuzzle.dsl.storage.store).be.calledOnce();
+      should(context.accessors.kuzzle.dsl.storage.store).be.calledWithMatch('index', 'collection', {some: 'filters'});
+    });
   });
 
   describe('#mergeAddRoom', () => {
     var mergeAddRoom = Node.__get__('mergeAddRoom');
 
     it('should update the hotelclerk', () => {
-      mergeAddRoom.call(node, {
+      mergeAddRoom(node.kuzzle.hotelClerk, {
         i: 'index',
         c: 'collection',
         ch: ['channelId', 'states'],
@@ -216,7 +202,7 @@ describe('lib/cluster/node', () => {
     var mergeDelRoom = Node.__get__('mergeDelRoom');
 
     it('should remove the room entry', () => {
-      mergeDelRoom.call(node, {
+      mergeDelRoom(node.kuzzle.hotelClerk, {
         c: {id: 'myconnection'},
         r: 'roomId'
       });
@@ -231,8 +217,8 @@ describe('lib/cluster/node', () => {
 
     it('should call hotelClerk::removeRooms', () => {
       var response;
-      
-      mergeDelRooms.call(node, {i: 'index', c: 'collection', r: ['room1', 'room2']});
+
+      mergeDelRooms(node.kuzzle.hotelClerk, {i: 'index', c: 'collection', r: ['room1', 'room2']});
 
       should(node.kuzzle.hotelClerk.removeRooms).be.calledOnce();
       response = node.kuzzle.hotelClerk.removeRooms.firstCall.args[0];
@@ -243,45 +229,14 @@ describe('lib/cluster/node', () => {
     });
   });
 
-  describe('#mergeFilterTree', () => {
-    var mergeFilterTree = Node.__get__('mergeFilterTree');
-
-    it('should call filters::add with valid values', () => {
-      mergeFilterTree.call(node, {
-        i: 'index',
-        c: 'collection',
-        f: 'foo',
-        o: 'term',
-        v: 'bar',
-        fn: 'psFN3PWCau+CKQl9gdT23g==',
-        fi: '5761ee80ef2676204f6b3ac960779586',
-        n: true,
-        g: true
-      });
-
-      should(node.kuzzle.dsl.filters.add).be.calledOnce();
-      should(node.kuzzle.dsl.filters.add).be.calledWith(
-        'index',
-        'collection',
-        'foo',
-        'term',
-        'bar',
-        'psFN3PWCau+CKQl9gdT23g==',
-        '5761ee80ef2676204f6b3ac960779586',
-        true,
-        true
-      );
-    });
-  });
-
   describe('#updateAutoRefresh', () => {
     var updateAutoRefresh = Node.__get__('updateAutoRefresh');
 
     it('should call kuzzle write engine with a valid requestObject', () => {
-      var 
+      var
         requestObject;
-      
-      updateAutoRefresh.call(node, 'index', 'value');
+
+      updateAutoRefresh(node.kuzzle.services.list.storageEngine, 'index', 'value');
 
       should(node.kuzzle.services.list.storageEngine.setAutoRefresh).be.calledOnce();
       requestObject = node.kuzzle.services.list.storageEngine.setAutoRefresh.firstCall.args[0];

--- a/test/lib/cluster/slaveNode.test.js
+++ b/test/lib/cluster/slaveNode.test.js
@@ -18,35 +18,35 @@ describe('lib/cluster/slaveNode', () => {
         kuzzle: {
           services: { list: { broker: {} } },
           hotelClerk: { rooms: 'rooms', customers: 'customers' },
-          dsl: { filters: { filtersTree: 'filterTree', filters: 'filters' } },
+          dsl: { filters: { filters: 'filters' } },
           indexCache: { indexes: 'indexes' }
         }
       }
     },
     options = {binding: 'binding', host: '_host', port: '_port'};
-  
+
   afterEach(() => {
     sandbox.restore();
   });
 
   describe('#constructor', () => {
-    
+
     it('should create a valid slave node object', () => {
       var node = new SlaveNode(clusterHandler, context, options);
-      
+
       should(node.kuzzle).be.exactly(context.accessors.kuzzle);
       should(node.options).be.exactly(options);
     });
-    
+
     it('should inherit from Node', () => {
       var node = new SlaveNode(clusterHandler, context, options);
-      
+
       should(node).be.an.instanceOf(Node);
     });
   });
 
   describe('#init', () => {
-    var 
+    var
       attachEventsSpy = sinon.spy(),
       wsClientSpy = sinon.spy(function () {
         this.init = () => Promise.resolve();    // eslint-disable-line no-invalid-this
@@ -62,7 +62,7 @@ describe('lib/cluster/slaveNode', () => {
     after(() => {
       reset();
     });
-    
+
 
     it('should set the broker and attach the events', () => {
       var node = {
@@ -79,7 +79,7 @@ describe('lib/cluster/slaveNode', () => {
         options: 'options',
         kuzzle: {pluginsManager: 'pluginsManager'}
       };
-      
+
       return SlaveNode.prototype.init.call(node)
         .then(() => {
           should(node.broker).be.an.Object();
@@ -93,9 +93,9 @@ describe('lib/cluster/slaveNode', () => {
           should(attachEventsSpy).be.calledOnce();
         });
     });
-    
+
   });
-  
+
   describe('#attachEvents', () => {
     var
       attachEvents = SlaveNode.__get__('attachEvents'),
@@ -117,12 +117,12 @@ describe('lib/cluster/slaveNode', () => {
         options: 'options'
       },
       reset;
-    
+
     before(() => {
       joinSpy = sandbox.spy(SlaveNode.__get__('join'));
       reset = SlaveNode.__set__('join', joinSpy);
     });
-    
+
     after(() => {
       reset();
     });
@@ -142,22 +142,22 @@ describe('lib/cluster/slaveNode', () => {
       should(node.broker.onConnectHandlers).have.length(1);
       should(node.broker.onCloseHandlers).have.length(1);
       should(node.broker.onErrorHandlers).have.length(1);
-      
+
       // onJoin
       node.isReady = false;
       node.broker.onConnectHandlers[0]();
       should(joinSpy).have.callCount(2);
-      
+
       // onClose
       node.isReady = true;
       node.broker.onCloseHandlers[0]();
       should(node.isReady).be.false();
-      
+
       // onError
       node.isReady = true;
       node.broker.onErrorHandlers[0]();
       should(node.isReady).be.false();
-      
+
       // cb
       cb.call(node, {
         action: 'snapshot',
@@ -167,14 +167,14 @@ describe('lib/cluster/slaveNode', () => {
           ic: 'uindexCache'
         }
       });
-      
+
       should(node.kuzzle.hotelClerk.rooms).be.exactly('urooms');
       should(node.kuzzle.hotelClerk.customers).be.exactly('ucustomers');
       should(node.kuzzle.dsl.filters.filtersTree).be.exactly('ufiltersTree');
       should(node.kuzzle.dsl.filters.filters).be.exactly('ufilters');
       should(node.kuzzle.indexCache.indexes).be.exactly('uindexCache');
-      
-      
+
+
     });
 
   });


### PR DESCRIPTION
* remove support for the now obsolete `ft` and `ftG` keys
* add support for the new `ftAdd` key, instructing a node to register a new canonicalized filter
* add `use strict` instruction and adapted code to make it compatible with strict mode
* solve a potential bug when scanning merge objects, where only the 1st key was expected to be a merge object