### PR TITLE
Better check binding syntax 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -186,7 +186,7 @@ class KuzzleCluster {
     };
 
     debug('[%s] broadcasting "profile update" action: %a', this.uuid, msg);
-    
+
     this.node.broker.broadcast('cluster:update', [msg]);
   }
 
@@ -393,25 +393,28 @@ class KuzzleCluster {
       host = match[1];
 
       // [eth0:ipv4] case test
-      match = /^\[(.*?):(.*?)]/.exec(host);
-
+      match = /^\[(.*?)]/.exec(host);
       if (match) {
-        iface = match[1];
-        family = match[2].toLowerCase();
+        const binding = /^(.*?):(.*?)$/.exec(match[1]);
 
-        if (os.networkInterfaces()[iface]) {
-          tmp = os.networkInterfaces()[iface].filter(def => family === def.family.toLowerCase());
-
-          if (tmp.length) {
-            host = tmp[0].address;
-          }
-          else {
-            throw new InternalError(`Invalid ip family provided [${family}] for network interface ${iface}`);
-          }
+        if (! binding) {
+          throw new InternalError(`Invalid binding pattern [${match[1]}]`);
         }
-        else {
+
+        iface = binding[1];
+        family = binding[2].toLowerCase();
+
+        if (! os.networkInterfaces()[iface]) {
           throw new InternalError(`Invalid network interface provided [${iface}]`);
         }
+
+        tmp = os.networkInterfaces()[iface].filter(def => family === def.family.toLowerCase());
+
+        if (! tmp.length) {
+          throw new InternalError(`Invalid ip family provided [${family}] for network interface ${iface}`);
+        }
+
+        host = tmp[0].address;
       }
     }
 


### PR DESCRIPTION
# Description:

Partial fix of #37 

host binding pattern `[...]` binding without ':' separator are now forbidden:
* `[eth0:ipv4]` => accepted
* `[eth0.ipv4]` => denied
* `custom-hostname` => accepted
* `[custom-hostname]` => denied

# Boyscout:
Fix some broken unit tests