### PR TITLE
autogenerate node uuid to avoid collisions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const
   debug = require('./kuzzleDebug')('kuzzle:cluster'),
   os = require('os'),
+  uuid = require('uuid'),
   InternalError = require('kuzzle-common-objects').errors.InternalError,
   MasterNode = require('./cluster/masterNode'),
   SlaveNode = require('./cluster/slaveNode');
@@ -79,7 +80,7 @@ class KuzzleCluster {
       retryInterval: 2000
     }, config || {});
     this.config.binding = this._resolveBinding();
-    this.uuid = this.config.binding.host + ':' + this.config.binding.port;
+    this.uuid = uuid.v4();
 
     // used only for core-dump analysis
     this.isMasterNode = false;


### PR DESCRIPTION
It will avoid the case where 2 distinct cluster nodes would have the same uuid coming from settings
(for example with hardcoded network binding).

Fix #37 