### PR TITLE
dev stack - fix empty nginx upstream

### DIFF
--- a/docker-compose/nginx/tpl/kuzzle.conf.tpl
+++ b/docker-compose/nginx/tpl/kuzzle.conf.tpl
@@ -4,10 +4,8 @@ map $http_upgrade $connection_upgrade {
 }
 
 upstream kuzzle {
-{{range $services := service "kuzzle"}}{{scratch.Set "has_services" true}}
-  server {{.Address}}:7512; {{end}}
-{{with $has_service := scratch.Get "has_services"}}{{if not $has_service}}
-  server 127.0.0.1:80; {{end}}{{end}}
+{{range $services := service "kuzzle"}}
+  server {{.Address}}:7512;{{else}}  server localhost:80;{{end}}
 }
 
 server {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cluster",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Enterprise only - enables Kuzzle cluster mode",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes nginx crashing with
```
2018/06/12 12:57:23 [emerg] 1#1: no servers are inside upstream in /etc/nginx/conf.d/kuzzle.conf:9
nginx: [emerg] no servers are inside upstream in /etc/nginx/conf.d/kuzzle.conf:9
```

## root cause

Nginx configuration is templated by consul-template. The containers can take some delay to register into consul.
If the template is compiled before any kuzzle node is marked as available the upstream directive would end up empty and crash nginx.

## work around

When no node is available, auto-proxy to default 80 port.
