### PR TITLE
Google chrome devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ In other words, when adding a node to the cluster, haproxy (at least up to curre
 * [http://localhost:7512/_plugin/cluster/status] => cluster status
 * `curl -XPOST http://localhost:7512/_plugin/cluster/reset` => resets redis state and force a new sync (blanks cluster state)
 * [http://localhost:7512/cluster_kuzzle_1/] prefixing the url by the container name lets you access it directly
+* `bash docker-compose/scripts/devtools.sh` dumps to the standard output the urls to copy/paste in Google Chrome to live-debug the nodes
 
 ## Configuration
 

--- a/docker-compose/docker-compose.yml.tpl
+++ b/docker-compose/docker-compose.yml.tpl
@@ -27,7 +27,7 @@ services:
       c2c_consul__host: consul
 
   haproxy:
-    image: haproxy:1.7-alpine
+    image: haproxy:1.8-alpine
     command: sh -c 'exec tail -f /dev/null'
     container_name: haproxy
     ports:


### PR DESCRIPTION
A small PR to update the README to include the way of getting chrome devtools urls.

Other change: ugrade haproxy from 1.7 to 1.8.